### PR TITLE
Add Flask Live Templates link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Linux.  (2017/05/05, Curso em Video)
 integrates MongoDB Servers with database/collections tree, Query Runner and 
 Shell console. *(2017-12-12)*
 
+## Live Templates
+
+* [Flask PyCharm Templates](https://github.com/mstuttgart/flask-pycharm-templates)
+Collection of live templates to help you develop Flask web applications. *(2017-10-08, Michell Stuttgart)*
+
 # Contributing
 
 Your contributions are always welcome! Please take a look at the 


### PR DESCRIPTION
Hi! This PR add the follow items:

* [NEW] Create Live Templates section
* [NEW] Add link to PyCharm Flask Live Templates

Awesome idea. Thanks :)